### PR TITLE
feat: added blackBg color

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -83,6 +83,7 @@ Lunacolors.format = function(text)
 		magenta = {'{magenta}', ansi(35)},
 		cyan = {'{cyan}', ansi(36)},
 		white = {'{white}', ansi(37)},
+		black_bg = {'{blackBg}', ansi(40)},
 		red_bg = {'{redBg}', ansi(41)},
 		green_bg = {'{greenBg}', ansi(42)},
 		yellow_bg = {'{yellowBg}', ansi(43)},


### PR DESCRIPTION
With this pr the user that uses lunacolor, should can use the missing color `{blackBg}` in the `.format` function, e.g:

```lua
lunacolors = require("lunacolors")

print(lunacolors.format("{black}{green}{blackBg}  {white}username {black}{reset}{black}\n{reset}$ "))
```

That's an example of the usage of blackBg to render a simple prompt string with nerd fonts